### PR TITLE
Fix for when updating a DataPackageR Project 

### DIFF
--- a/R/prompt.R
+++ b/R/prompt.R
@@ -66,11 +66,11 @@
   news_con <- file(news_file, open = "r+")
   news_file_data <- readLines(news_con)
   header_1 <- grep("DataVersion", news_file_data)[1]
-  header_2 <- grep("DataVersion", news_file_data)[2]
+  # header_2 <- grep("DataVersion", news_file_data)[2]
   ul_1 <- grep("=====", news_file_data)[1]
-  ul_2 <- grep("=====", news_file_data)[2]
+  # ul_2 <- grep("=====", news_file_data)[2]
   assert_that(header_1 == ul_1 - 1)
-  assert_that(header_2 == ul_2 - 1)
+  # assert_that(header_2 == ul_2 - 1)
   header <- news_file_data[header_1:ul_1]
   news_file_data <- news_file_data[-c(header_1:ul_1)]
   #write header

--- a/tests/testthat/test-updating-datapackager-version.R
+++ b/tests/testthat/test-updating-datapackager-version.R
@@ -1,0 +1,33 @@
+context("updating datapackager API version")
+test_that("can update", {
+  
+  #setup, build example package
+  file <- system.file("extdata", "tests", "subsetCars.Rmd",
+                      package = "DataPackageR"
+  )
+  file2 <- system.file("extdata", "tests", "extra.rmd",
+                       package = "DataPackageR"
+  )
+  expect_null(
+    datapackage_skeleton(
+      name = "subsetCars",
+      path = tempdir(),
+      code_files = c(file, file2),
+      force = TRUE,
+      r_object_names = c("cars_over_20")
+    )
+  )
+  package_build(file.path(tempdir(), "subsetCars"))
+  
+  #remove news.md and modify with the digest so it thinks there has been an update when rebuilt
+  file.remove(file.path(tempdir(),"subsetCars","news.md"))
+  oldDigest<-.parse_data_digest(file.path(tempdir(),"subsetCars"))
+  oldDigest$cars_over_20<-"123456789"
+  DataPackageR:::.save_digest(oldDigest,file.path(tempdir(),"subsetCars"))
+  
+  expect_identical(
+    try(package_build(file.path(tempdir(), "subsetCars"))),
+    normalizePath(file.path(tempdir(),"subsetCars_1.0.tar.gz"),winslash = "/")
+  )#if it passes, it returns the path to the tar file?
+  
+})


### PR DESCRIPTION
…arching and comparison of a secondary header was unnecessary. Broke out change to its own branch. Included test

<!-- IF THIS INVOLVES AUTHENTICATION: DO NOT SHARE YOUR USERNAME/PASSWORD, OR API KEYS/TOKENS IN THIS ISSUE - MOST LIKELY THE MAINTAINER WILL HAVE THEIR OWN EQUIVALENT KEY -->

<!-- If you've updated a file in the man-roxygen directory, make sure to update the man/ files by running devtools::document() or similar as .Rd files should be affected by your change -->

<!--- Provide a general summary of your changes in the Title above -->
Found a bug when running package_build when a news.md file did not exist, but a DATADIGEST did

## Description
<!--- Describe your changes in detail -->
Found this bug when updating an old datapackages to the new API and simultaneously making changes out the out. The issue is that a DATADIGEST exists from the old API, so when running the build and it find that there are changes to the objects, it tries to document them in the news file via .update_news_changed_objects. However, since the news.md file did not exist before, when it looked for the second existence of a header entry, it did not find it. I did not see why it was looking for the old headers, as it is not used anywhere else in the function. 

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->

<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->
