### PR TITLE
expanded datapackager_object_read  functionality

### DIFF
--- a/R/01.R
+++ b/R/01.R
@@ -1,3 +1,4 @@
 .onLoad <- function(libname, pkgname) {
   options("DataPackageR_interact" = interactive())
+  options("DataPackageR_packagebuilding" = FALSE)
 }

--- a/R/environments.R
+++ b/R/environments.R
@@ -23,5 +23,43 @@
 #'                                     # appear in the objects property of config.yml
 #' }
 datapackager_object_read <- function(name) {
-  get(name, get("ENVS", parent.frame()))
+  
+  # get(name, get("ENVS", parent.frame()))
+  
+  #when the datapackage is being build, it will only read the object from the environment. when
+  # in interactive mode, it should be try to load the objects reviously generated. 
+  # It will preferentially read the object from the the temporary folder, but if that does not exist, it will read the
+  # object from the the data folder
+  buildingPackage<-getOption("DataPackageR_packagebuilding",TRUE)
+  
+  
+  object<-try(get(name, get("ENVS", parent.frame())),silent=TRUE)
+  
+  if( !buildingPackage && inherits(object,"try-error")){
+    #if the package is not being build and the object is not found in the "ENVS" environment
+    temp_folder_path<-file.path(tempdir(),yml_find(usethis::proj_get())[["configuration"]][["render_root"]]$tmp)
+    
+    if(file.exists(objectPath<-file.path(temp_folder_path,paste0(name,".rds")))){
+      message('loading ',name,' from temporary folder from previous build attempt.')
+      object<-readRDS(objectPath)
+      
+    }else if(file.exists(objectPath<-file.path(project_data_path(),paste0(name,".rda")))){
+      message('loading ',name,' from data directory.')
+      print(objectPath)
+      load_env<-new.env()
+      load(objectPath,envir = load_env)
+      object<-load_env[[ls(load_env)[1]]]
+      
+    }else{
+      stop(paste(name,'not found!'))
+      
+    }
+  }else if(inherits(object,"try-error")){
+    #if the package is being build and the object is not found in the "ENVS" environment,
+    # pass on the original error warning
+    stop(object[1])
+    
+  }
+  
+  return(object)
 }

--- a/R/processData.R
+++ b/R/processData.R
@@ -125,6 +125,12 @@ DataPackageR <- function(arg = NULL, deps = TRUE) {
   raw_data_dir <- "data-raw"
   target <- normalizePath(file.path(pkg_dir, raw_data_dir), winslash = "/")
   raw_data_dir <- target
+  
+  #set the option that DataPackageR is building the package. On exit ensures when it leaves, it will set it back to false
+  options("DataPackageR_packagebuilding" = TRUE)
+  on.exit(options("DataPackageR_packagebuilding" = FALSE))
+  
+  
 
   # validate that render_root exists.
   # if it's an old temp dir, what then?


### PR DESCRIPTION
Code and tests for interacting more easily with the files that are generated and saved in the render root or data dir

<!-- IF THIS INVOLVES AUTHENTICATION: DO NOT SHARE YOUR USERNAME/PASSWORD, OR API KEYS/TOKENS IN THIS ISSUE - MOST LIKELY THE MAINTAINER WILL HAVE THEIR OWN EQUIVALENT KEY -->

<!-- If you've updated a file in the man-roxygen directory, make sure to update the man/ files by running devtools::document() or similar as .Rd files should be affected by your change -->

<!--- Provide a general summary of your changes in the Title above -->
added ability and tests for reading the objects stored in the render root on the case of failure. 

## Description
<!--- Describe your changes in detail -->
datapackager_object_read will now be able to look at several locations for objects from which to read; first it will look in the render root. if that fails, it will then look in the data directory for the file. Should make it easier for debugging, etc. 

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->

<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->
