### PR TITLE
Add input check for use_data_object

### DIFF
--- a/R/use.R
+++ b/R/use.R
@@ -187,6 +187,8 @@ use_processing_script <- function(file = NULL, title = NULL, author = NULL, over
 use_data_object <- function(object_name = NULL) {
   if (is.null(object_name)) {
     stop(paste0(object_name, " cannot be NULL."))
+  } else if(!is.character(object_name) | !length(object_name)==1){
+    stop("object_name must be a character vector of length 1.")
   } else {
     proj_path <- usethis::proj_get()
     yml <- yml_find(path = proj_path)

--- a/tests/testthat/test-use_raw_data.R
+++ b/tests/testthat/test-use_raw_data.R
@@ -122,6 +122,8 @@ test_that("use_data_object works as expected", {
   )
   expect_true(use_data_object("newobject"))
   expect_error(use_data_object(object_name = NULL))
+  expect_error(use_data_object(object_name = 1))
+  expect_error(use_data_object(object_name = c("a","b")))
 })
 
 test_that(".update_header", {


### PR DESCRIPTION
## Description

The `use_data_object` requires a character vector as the input. However, previously no check was present to check this. This could result in incorrect additions to the datapackager.yml file. If the user accidentally provided the name of the object as a symbol rather than a character, then the elements of the object would be written to the yml file rather than the object itself.

This commit adds a check for a the input of `use_data_object` to be a character vector. In addition, since the package description for the function requires that the input have length 1, a check is made for this (but this restriction may be unnecessary).

## Tests

Two tests are added to check that an error occurs when either the input is not a character vector or has length other than one.


## Changes to be committed:
	modified:   R/use.R
	modified:   tests/testthat/test-use_raw_data.R