### PR TITLE
Set working dir after unlinking of current dir.

### DIFF
--- a/tests/testthat/test-edge-cases.R
+++ b/tests/testthat/test-edge-cases.R
@@ -115,6 +115,7 @@ test_that("package built in different edge cases", {
     recursive = TRUE,
     force = TRUE
   )
+  setwd(old)
 
   yml <- DataPackageR:::construct_yml_config("foo.Rmd")
   expect_true(yml_enable_compile(


### PR DESCRIPTION
Fix CI error for Mac and Linux

## Description
GitHub Actions identified an issue while running tests for Mac and Linux. The issue was found to be in how the one of the test files was written, and the resulting behavior was different on Windows than Mac or Linux. This issue was that one of the test files was deleting the working directory in its procedure. In Linux and Mac OS this will set the working directory to NULL, but in Windows the folder is not deleted and the working directory does not change. The solution was to reset the working directory after deleting.
