### PR TITLE
Remove all R versions < 3.5, add missing Linux system dependencies

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -30,8 +30,6 @@ jobs:
           - {os: ubuntu-20.04,   r: 'devel',   rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
           - {os: ubuntu-20.04,   r: '3.6',     rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
           - {os: ubuntu-20.04,   r: '3.5',     rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
-          - {os: ubuntu-20.04,   r: '3.4',     rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
-          - {os: ubuntu-20.04,   r: '3.3',     rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
@@ -69,6 +67,11 @@ jobs:
           do
             eval sudo $cmd
           done < <(Rscript -e 'writeLines(remotes::system_requirements("ubuntu", "20.04"))')
+
+      - name: Install other Linux system dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt install libicu-dev
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -28,8 +28,8 @@ jobs:
           - {os: macOS-latest,   r: 'release'}
           - {os: ubuntu-20.04,   r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
           - {os: ubuntu-20.04,   r: 'devel',   rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
-          - {os: ubuntu-20.04,   r: '3.6',     rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
-          - {os: ubuntu-20.04,   r: '3.5',     rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
+          - {os: ubuntu-20.04,   r: '3.6',     rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"} 
+          - {os: ubuntu-20.04,   r: '3.5',     rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
@@ -71,7 +71,7 @@ jobs:
       - name: Install other Linux system dependencies
         if: runner.os == 'Linux'
         run: |
-          sudo apt install libicu-dev
+          sudo apt install libicu66
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -68,11 +68,6 @@ jobs:
             eval sudo $cmd
           done < <(Rscript -e 'writeLines(remotes::system_requirements("ubuntu", "20.04"))')
 
-      - name: Install other Linux system dependencies
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt install libicu66
-
       - name: Install dependencies
         run: |
           remotes::install_deps(dependencies = TRUE)


### PR DESCRIPTION
## Description
Missing Linux system dependencies were causing failures in older R versions. Also, DataPackageR does not support R versions < 3.5. Those versions were removed from CI.

## Related Issues
Issues #75, #78  
