### PR TITLE
Fix deprecated roxygen2 pkg-level documentation in pkg and template

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,16 +1,10 @@
-# For help debugging build failures open an issue on the RStudio community with the 'github-actions' tag.
-# https://community.rstudio.com/new-topic?category=Package%20development&tags=github-actions
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches:
-      - main
-      - master
-      - develop
+    branches: [main, master, develop]
   pull_request:
-    branches:
-      - main
-      - master
-      - develop
+    branches: [main, master, develop]
 
 name: R-CMD-check
 
@@ -24,73 +18,34 @@ jobs:
       fail-fast: false
       matrix:
         config:
+          - {os: macos-latest,   r: 'release'}
           - {os: windows-latest, r: 'release'}
-          - {os: macOS-latest,   r: 'release'}
-          - {os: ubuntu-20.04,   r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
-          - {os: ubuntu-20.04,   r: 'devel',   rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
-          - {os: ubuntu-20.04,   r: '3.6',     rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"} 
-          - {os: ubuntu-20.04,   r: '3.5',     rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
+          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
+          - {os: ubuntu-latest,   r: 'release'}
+          - {os: ubuntu-latest,   r: 'oldrel-1'}
+          - {os: ubuntu-latest,   r: '4.0.4'}
 
     env:
-      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-      RSPM: ${{ matrix.config.rspm }}
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
 
-      - uses: r-lib/actions/setup-pandoc@v1
-
-      - name: Query dependencies
-        run: |
-          install.packages('remotes')
-          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
-          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
-        shell: Rscript {0}
-
-      - name: Cache R packages
-        if: runner.os != 'Windows'
-        uses: actions/cache@v2
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
-          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+          extra-packages: any::rcmdcheck
+          needs: check
 
-      - name: Install system dependencies
-        if: runner.os == 'Linux'
-        run: |
-          while read -r cmd
-          do
-            eval sudo $cmd
-          done < <(Rscript -e 'writeLines(remotes::system_requirements("ubuntu", "20.04"))')
-
-      - name: Install dependencies
-        run: |
-          remotes::install_deps(dependencies = TRUE)
-          remotes::install_cran("rcmdcheck")
-          remotes::install_cran("covr")
-          install.packages("tinytex")
-          library(tinytex)
-          install_tinytex()
-        shell: Rscript {0}
-
-      - name: Check
-        env:
-          _R_CHECK_CRAN_INCOMING_REMOTE_: false
-        run: rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "check")
-        shell: Rscript {0}
-
-      - name: Upload check results
-        if: failure()
-        uses: actions/upload-artifact@main
+      - uses: r-lib/actions/check-r-package@v2
         with:
-          name: ${{ runner.os }}-r${{ matrix.config.r }}-results
-          path: check
-
-      - name: Test coverage
-        run: covr::codecov()
-        shell: Rscript {0}
+          upload-snapshots: true
+          build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -40,6 +40,8 @@ jobs:
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
+      - uses: r-lib/actions/setup-tinytex@v2
+
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::rcmdcheck

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -48,7 +48,7 @@ Imports:
     crayon,
     withr
 VignetteBuilder: knitr
-RoxygenNote: 7.1.1
+RoxygenNote: 7.3.1
 Encoding: UTF-8
 Suggests:
     spelling,

--- a/R/autodoc.R
+++ b/R/autodoc.R
@@ -22,7 +22,6 @@
         c(
           pname,
           paste0("A data package for ", pname, "."),
-          "@docType package",
           paste0("@aliases ", pname, "-package"),
           "@title Package Title",
           paste0("@name ", pname),
@@ -40,7 +39,7 @@
           linksrox[2:length(links)]
         )
       ),
-      "NULL\n\n\n"
+      "'_PACKAGE'\n\n\n"
     ), con
   )
 

--- a/R/processData.R
+++ b/R/processData.R
@@ -79,9 +79,8 @@
 #' # view the documentation with
 #' ?tbl
 #' }
-#' @docType package
 #' @name DataPackageR-package
-NULL
+'_PACKAGE'
 
 
 .validate_render_root <- function(x) {

--- a/man/DataPackageR-package.Rd
+++ b/man/DataPackageR-package.Rd
@@ -87,3 +87,30 @@ readLines(list.files(pattern="R", path = file.path(tempdir(),pname,"R"), full = 
 ?tbl
 }
 }
+\seealso{
+Useful links:
+\itemize{
+  \item \url{https://docs.ropensci.org/DataPackageR/ (website) https://github.com/ropensci/DataPackageR/}
+  \item Report bugs at \url{https://github.com/ropensci/DataPackageR/issues}
+}
+
+}
+\author{
+\strong{Maintainer}: Marie Vendettuoli \email{sc.mvendett.viscdevelopers@scharp.org} [contributor]
+
+Authors:
+\itemize{
+  \item Greg Finak \email{greg.finak@gmail.com} (Original author and creator of DataPackageR) [copyright holder]
+}
+
+Other contributors:
+\itemize{
+  \item Paul Obrecht [contributor]
+  \item Ellis Hughes \email{ellishughes@live.com} [contributor]
+  \item Jimmy Fulp \email{williamjfulp@gmail.com} [contributor]
+  \item Jason Taylor \email{jmtaylor@fredhutch.org} [contributor]
+  \item Kara Woo (Kara reviewed the package for ropensci, see <https://github.com/ropensci/onboarding/issues/230>) [reviewer]
+  \item William Landau (William reviewed the package for ropensci, see <https://github.com/ropensci/onboarding/issues/230>) [reviewer]
+}
+
+}

--- a/tests/testthat/test-document.R
+++ b/tests/testthat/test-document.R
@@ -46,10 +46,15 @@ test_that("documentation is built via document()", {
   )
   flush(connection)
   close(connection)
-  expect_output(
-    document(file.path(tempdir(), "subsetCars"), lib = temp_libpath),
-    "Writing testmarkdownroxygen.Rd"
+
+  path_chk <- file.path(tempdir(), "subsetCars")
+  files_before <- list.files(path_chk, recursive = TRUE)
+  document(path_chk, lib = temp_libpath)
+  files_after <- list.files(path_chk, recursive = TRUE)
+  expect_true(
+    setdiff(files_after, files_before) == "man/testmarkdownroxygen.Rd"
   )
+
   v <- vignette(package = "subsetCars", lib.loc = temp_libpath)
   expect_equal(v$results[, "Item"], "subsetCars")
   unlink(file.path(tempdir(), "subsetCars"),


### PR DESCRIPTION
`DataPackageR` currently uses package-level documentation syntax that has been [deprecated ](https://github.com/r-lib/roxygen2/issues/1491)in `roxygen2` since ~2019.  It uses this both for its own package-level documentation and in its template for creating new data package skeletons.

With recent versions of `roxygen2`, e.g. `7.3.1`, the warning surfaces both during routine building of data packages and during R CMD check.

```
✖ Schief546.R:13: `@docType "package"` is deprecated.
ℹ Please document "_PACKAGE" instead.
```

https://github.com/ropensci/DataPackageR/commit/517198fee9832ad6e9325deb2982a51fec0b09d9 fixes the data package skeleton template. Keeping the `@name` tag is not required by `roxygen2` but is necessary for fragile-looking downstream scraping functionality in `DataPackageR` to still work without modifications.

https://github.com/ropensci/DataPackageR/commit/95957a0ea3881bf88c0524fc25d74ef49e9eed68 fixes `DataPackageR`'s own documentation. The new method auto-generates some additional author info etc. for the package-level `.Rd` file.

One broken unit test needed to be updated to be be more robust.

I installed this branch locally and did a test build of `Schief546` to verify that the build still works and the warning no longer appears. With this PR, the package also passes `devtools::check()` cleanly on my local machine.

This is probably not directly relevant to DPR2, since @jmtaylor-fhcrc et al. have presumably been using newer `roxygen2` versions.