### PR TITLE
make pkg template depend on R v3.5.0, due to .rda method

### DIFF
--- a/R/skeleton.R
+++ b/R/skeleton.R
@@ -67,6 +67,7 @@ datapackage_skeleton <-
     description$set("DataVersion" = "0.1.0")
     description$set("Version" = "1.0")
     description$set("Package" = name)
+    description$set_dep("R", "Depends", ">= 3.5.0")
     description$set("Roxygen" = "list(markdown = TRUE)")
     description$write()
     .done(paste0("Added DataVersion string to ", crayon::blue("'DESCRIPTION'")))


### PR DESCRIPTION
Adjusted DESCRIPTION template so that created data packages depend on R version > 3.5.0

This already happens during installation of a data package, but with 1 warning per serialized data object.  This change suppresses those warnings.

Fixes #114.

Also see #75.