### PR TITLE
Cran edits

### DIFF
--- a/R/build.R
+++ b/R/build.R
@@ -10,6 +10,7 @@
 #' @param deps \code{logical} should we pass data objects into subsequent scripts? Default TRUE
 #' @param install \code{logical} automatically install and load the package after building. Default FALSE
 #' @param ... additional arguments passed to \code{install.packages} when \code{install=TRUE}.
+#' @returns Character vector. File path of the built package.
 #' @importFrom roxygen2 roxygenise roxygenize
 #' @importFrom devtools build_vignettes build parse_deps reload
 #' @importFrom usethis use_build_ignore use_rstudio proj_set use_directory
@@ -132,6 +133,7 @@ package_build <- function(packageName = NULL,
 #' @name keepDataObjects-defunct
 #' @aliases  keepDataObjects
 #' @param ... arguments
+#' @returns Defunct. No return value.
 #' @rdname keepDataObjects-defunct
 #' @export
 keepDataObjects <- function(...) {

--- a/R/dataversion.R
+++ b/R/dataversion.R
@@ -8,6 +8,7 @@
 #' @param lib.loc \code{character} path to library location.
 #' @seealso \code{\link[utils]{packageVersion}}
 #' @rdname data_version
+#' @returns Object of class 'package_version' and 'numeric_version' specifying the DataVersion of the package
 #' @note \code{dataVersion()} has been renamed to \code{data_version()}
 #' @importFrom utils capture.output file_test package.skeleton packageDescription
 #' @export

--- a/R/digests.R
+++ b/R/digests.R
@@ -4,13 +4,13 @@
 
 .check_dataversion_string <- function(old_data_digest, new_data_digest) {
   oldwarn <- options("warn")$warn
-  options(warn = -1)
-  oldv <- strsplit(old_data_digest[["DataVersion"]], "\\.")
-  newv <- strsplit(new_data_digest[["DataVersion"]], "\\.")
-  oldv <- lapply(oldv, as.numeric)[[1]]
-  newv <- lapply(newv, as.numeric)[[1]]
+  suppressWarnings({
+    oldv <- strsplit(old_data_digest[["DataVersion"]], "\\.")
+    newv <- strsplit(new_data_digest[["DataVersion"]], "\\.")
+    oldv <- lapply(oldv, as.numeric)[[1]]
+    newv <- lapply(newv, as.numeric)[[1]]
+  })
   if (any(is.na(oldv)) | any(is.na(newv))) {
-    options(warn = oldwarn)
     .multilog_fatal(paste0(
       "Invalid DataVersion string found ",
       old_data_digest[["DataVersion"]],
@@ -36,10 +36,10 @@
   existed <- names(new_digest)[names(new_digest) %in% names(old_digest)]
   added <- setdiff(names(new_digest), existed)
   removed <- names(old_digest)[!names(old_digest) %in% names(new_digest)]
-  existed <- existed[existed != "DataVersion"]  
+  existed <- existed[existed != "DataVersion"]
 
   if(length(existed) > 0){
-    changed <- names(new_digest)[ unlist(new_digest[existed]) != unlist(old_digest[existed]) ] 
+    changed <- names(new_digest)[ unlist(new_digest[existed]) != unlist(old_digest[existed]) ]
     if(length(changed) > 0){
       for(name in changed){
         .multilog_warn(paste(name, "has changed."))
@@ -53,7 +53,7 @@
     .multilog_debug(paste(name, "was removed."))
     return(FALSE)
   }
-  
+
   for(name in added){
     .multilog_debug(paste(name, "was added."))
     return(FALSE)
@@ -61,7 +61,7 @@
 
   return(TRUE)
 };
-  
+
 .combine_digests <- function(new, old) {
   intersection <- intersect(names(new), names(old))
   difference <- setdiff(names(new), names(old))

--- a/R/environments.R
+++ b/R/environments.R
@@ -11,7 +11,7 @@
 #' @return An R object.
 #' @export
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' if(rmarkdown::pandoc_available()){
 #' ENVS <- new.env() # ENVS would be in the environment
 #'                   # where the data processing is run. It is
@@ -25,43 +25,43 @@
 #' }
 #' }
 datapackager_object_read <- function(name) {
-  
+
   # get(name, get("ENVS", parent.frame()))
-  
+
   #when the datapackage is being build, it will only read the object from the environment. when
-  # in interactive mode, it should be try to load the objects reviously generated. 
+  # in interactive mode, it should be try to load the objects reviously generated.
   # It will preferentially read the object from the the temporary folder, but if that does not exist, it will read the
   # object from the the data folder
   buildingPackage<-getOption("DataPackageR_packagebuilding",TRUE)
-  
-  
+
+
   object<-try(get(name, get("ENVS", parent.frame(),inherits=FALSE),inherits=FALSE),silent=TRUE)
-  
+
   if( !buildingPackage && inherits(object,"try-error")){
     #if the package is not being build and the object is not found in the "ENVS" environment
     temp_folder_path<-file.path(tempdir(),yml_find(usethis::proj_get())[["configuration"]][["render_root"]]$tmp)
-    
+
     if(file.exists(objectPath<-file.path(temp_folder_path,paste0(name,".rds")))){
       message('loading ',name,' from temporary folder from previous build attempt.')
       object<-readRDS(objectPath)
-      
+
     }else if(file.exists(objectPath<-file.path(project_data_path(),paste0(name,".rda")))){
       message('loading ',name,' from data directory.')
       print(objectPath)
       load_env<-new.env()
       load(objectPath,envir = load_env)
       object<-load_env[[ls(load_env)[1]]]
-      
+
     }else{
       stop(paste(name,'not found!'))
-      
+
     }
   }else if(inherits(object,"try-error")){
     #if the package is being build and the object is not found in the "ENVS" environment,
     # pass on the original error warning
     stop(object[1])
-    
+
   }
-  
+
   return(object)
 }

--- a/R/processData.R
+++ b/R/processData.R
@@ -729,7 +729,7 @@ project_data_path <- function(file = NULL) {
 #' con <- file(f)
 #' writeLines("```{r}\n tbl = data.frame(1:10) \n```\n",con=con)
 #' close(con)
-#' \dontrun{
+#' \donttest{
 #' # construct a data package skeleton named "MyDataPackage" and pass
 #' # in the Rmd file name with full path, and the name of the object(s) it
 #' # creates.

--- a/R/processData.R
+++ b/R/processData.R
@@ -718,6 +718,7 @@ project_data_path <- function(file = NULL) {
 #' @param path \code{character} the path to the data package source root.
 #' @param install \code{logical} install and reload the package. (default TRUE)
 #' @param ... additional arguments to \code{install}
+#' @returns Called for side effects. Returns TRUE on successful exit.
 #' @export
 #' @examples
 #' # A simple Rmd file that creates one data object

--- a/R/skeleton.R
+++ b/R/skeleton.R
@@ -28,6 +28,7 @@
 #' @param r_object_names \code{vector} of quoted r object names , tables, etc. created when the files in \code{code_files} are run.
 #' @param raw_data_dir \code{character} pointing to a raw data directory. Will be moved with all its subdirectories to "inst/extdata"
 #' @param dependencies \code{vector} of \code{character}, paths to R files that will be moved to "data-raw" but not included in the yaml config file. e.g., dependency scripts.
+#' @returns No return value, called for side effects
 #' @note renamed \code{datapackage.skeleton()} to \code{datapackage_skeleton()}.
 #' @importFrom crayon bold green
 #' @export

--- a/man/data_version.Rd
+++ b/man/data_version.Rd
@@ -14,6 +14,9 @@ dataVersion(pkg, lib.loc = NULL)
 
 \item{lib.loc}{\code{character} path to library location.}
 }
+\value{
+Object of class 'package_version' and 'numeric_version' specifying the DataVersion of the package
+}
 \description{
 Retrieves the DataVersion of a package if available
 }

--- a/man/datapackage_skeleton.Rd
+++ b/man/datapackage_skeleton.Rd
@@ -45,6 +45,9 @@ into R objects.}
 
 \item{environment}{Not used.}
 }
+\value{
+No return value, called for side effects
+}
 \description{
 Creates a package skeleton directory structure for use with DataPackageR.
 Adds the DataVersion string to DESCRIPTION, creates the DATADIGEST file, and the data-raw directory.

--- a/man/datapackager_object_read.Rd
+++ b/man/datapackager_object_read.Rd
@@ -24,7 +24,7 @@ with objects specified in the yaml \code{objects} property and passed along
 to subsequent R and Rmd files as DataPackageR processes them in order.
 }
 \examples{
-\dontrun{
+\donttest{
 if(rmarkdown::pandoc_available()){
 ENVS <- new.env() # ENVS would be in the environment
                   # where the data processing is run. It is

--- a/man/document.Rd
+++ b/man/document.Rd
@@ -28,7 +28,7 @@ f <- file.path(f,"foo.Rmd")
 con <- file(f)
 writeLines("```{r}\n tbl = data.frame(1:10) \n```\n",con=con)
 close(con)
-\dontrun{
+\donttest{
 # construct a data package skeleton named "MyDataPackage" and pass
 # in the Rmd file name with full path, and the name of the object(s) it
 # creates.

--- a/man/document.Rd
+++ b/man/document.Rd
@@ -13,6 +13,9 @@ document(path = ".", install = TRUE, ...)
 
 \item{...}{additional arguments to \code{install}}
 }
+\value{
+Called for side effects. Returns TRUE on successful exit.
+}
 \description{
 Build documentation for a data package using DataPackageR.
 }

--- a/man/keepDataObjects-defunct.Rd
+++ b/man/keepDataObjects-defunct.Rd
@@ -10,6 +10,9 @@ keepDataObjects(...)
 \arguments{
 \item{...}{arguments}
 }
+\value{
+Defunct. No return value.
+}
 \description{
 These functions are no longer available.
 }

--- a/man/package_build.Rd
+++ b/man/package_build.Rd
@@ -26,6 +26,9 @@ package_build(
 
 \item{...}{additional arguments passed to \code{install.packages} when \code{install=TRUE}.}
 }
+\value{
+Character vector. File path of the built package.
+}
 \description{
 Combines the preprocessing, documentation, and build steps into one.
 }


### PR DESCRIPTION
First batch of edits addresses the following issues identified during manual CRAN submission review:

- Please add \value to .Rd files regarding exported methods and explain the functions results in the documentation. Please write about the structure of the output (class) and also what the output means. (If a function does not return a value, please document that too, e.g.
```
\value{No return value, called for side effects} or similar) Missing Rd-tags:
      data_version.Rd: \value
      datapackage_skeleton.Rd: \value
      document.Rd: \value
      keepDataObjects-defunct.Rd: \value
      package_build.Rd: \value
```

- \dontrun{} should only be used if the example really cannot be executed (e.g. because of missing additional software, missing API keys, ...) by the user. That's why wrapping examples in \dontrun{} adds the comment ("# Not run:") as a warning for the user. Does not seem necessary.
Please replace \dontrun with \donttest.
Please unwrap the examples if they are executable in < 5 sec, or replace dontrun{} with \donttest{}.
-> datapackager_object_read.R; document.Rd

- You are setting options(warn=-1) in your function. This is not allowed. Please rather use suppressWarnings() if really needed.
->  R/digests.R
```