### PR TITLE
Fix bullet spacing on console when there are multiple Deleted objects 

### DIFF
--- a/R/prompt.R
+++ b/R/prompt.R
@@ -89,7 +89,7 @@
   .write_changes <- function(string, news_con, what = NULL) {
     if (length(string) != 0) {
       if (getOption('DataPackageR_verbose', TRUE)){
-        cat(crayon::cyan(paste0("* ",what,": ",string,"\n")))
+        cat(crayon::cyan(paste0("* ",what,": ",string,"\n")), sep = "")
       }
        writeLines(text = paste0("* ",what,": ", string),
                   con = news_con,


### PR DESCRIPTION
Fixes #133.

`cat()` defaults to using a space as the separator, which prepends all bullets within an action category besides the first one. Changing `sep` to a blank string fixes it.