### PR TITLE
Local scoping and local tempdirs for edge case test file

### DIFF
--- a/R/DataPackageR-package.R
+++ b/R/DataPackageR-package.R
@@ -15,7 +15,7 @@
 #' "inst/extdata" but large raw data files can be read from sources external
 #' to the package source tree.
 #'
-#' Configuration is controlled via the config.yml file created at the package root.
+#' Configuration is controlled via the datapackager.yml file created at the package root.
 #' Its properties include a list of R and Rmd files that are to be rendered / sourced and
 #' which read data and do the actual processing.
 #' It also includes a list of r object names created by those files. These objects
@@ -33,7 +33,7 @@
 #' Once the package is built and installed, the data objects created in the package are accessible via
 #' the \code{data()} API, and
 #' Calling \code{datapackage_skeleton()} and passing in R / Rmd file names, and r object names
-#' constructs a skeleton data package source tree and an associated \code{config.yml} file.
+#' constructs a skeleton data package source tree and an associated \code{datapackager.yml} file.
 #'
 #' Calling \code{package_build()} sets the build process in motion.
 #' @examples

--- a/R/environments.R
+++ b/R/environments.R
@@ -21,7 +21,7 @@
 #' find_me <- datapackager_object_read("find_me") # This would appear in an Rmd processed by
 #'                                     # DataPackageR to access the object named "find_me" created
 #'                                     # by a previous script. "find_me" would also need to
-#'                                     # appear in the objects property of config.yml
+#'                                     # appear in the objects property of datapackager.yml
 #' }
 #' }
 datapackager_object_read <- function(name) {

--- a/inst/extdata/tests/extra.Rmd
+++ b/inst/extdata/tests/extra.Rmd
@@ -9,8 +9,8 @@ output: html_document
 knitr::opts_chunk$set(echo = TRUE)
 ```
 
-This file is processed second in the `config.yml` file. It therefore has access to the data objects
-created by `subsetCars.Rmd`, the file that is processed first in the `config.yml`.
+This file is processed second in the `datapackager.yml` file. It therefore has access to the data objects
+created by `subsetCars.Rmd`, the file that is processed first in the `datapackager.yml`.
 
 ## Reading objects from previously run files
 

--- a/inst/extdata/tests/subsetCars.Rmd
+++ b/inst/extdata/tests/subsetCars.Rmd
@@ -11,7 +11,7 @@ knitr::opts_chunk$set(echo = TRUE)
 This is a simple Rmd file that demonstrates how DataPackageR processes Rmarkdown files and creates data sets
 that are then stored in an R data package.
 
-In the `config.yml` for this example, this file is listed first, and therefore processed first.
+In the `datapackager.yml` for this example, this file is listed first, and therefore processed first.
 
 This particular document simply subsets the `cars` data set:
 
@@ -34,11 +34,11 @@ The data frame `cars_over_20` now holds this information.
 
 When DataPackageR processes this file, it creates this `cars_over_20` object. After processing the file it does several things:
 
-1. It compares the objects in the rmarkdown render environment of `subsetCars.Rmd` against the objects listed in the `config.yml` file `objects` property.
+1. It compares the objects in the rmarkdown render environment of `subsetCars.Rmd` against the objects listed in the `datapackager.yml` file `objects` property.
 2. It finds `cars_over_20` is listed there, so it stores it in a new environment.
 3. That environment is passed to subsequent R and Rmd files. Specifically when the `extra.Rmd` file is processed, it has access to an environment object that holds all the `objects` (defined in the yaml config) that have already been created and processed. This environment is passed into subsequent scripts at the `render()` call.
 
-All of the above is done automatically. The user only needs to list the objects to be stored and passed to other scripts in the `config.yml` file.
+All of the above is done automatically. The user only needs to list the objects to be stored and passed to other scripts in the `datapackager.yml` file.
 
 The `datapackager_object_read()` API can be used to retrieve these objects from the environment.
 
@@ -46,7 +46,7 @@ The `datapackager_object_read()` API can be used to retrieve these objects from 
 
 In addition to passing around an environment to subsequent scripts, the `cars_over_20` object is stored in the data package `/data` directory as an `rda` file.
 
-Note that this is all done automatically. The user does not need to explicitly save anything, they only need to list the objects to be store in the `config.yml`.
+Note that this is all done automatically. The user does not need to explicitly save anything, they only need to list the objects to be store in the `datapackager.yml`.
 
 This object is then accessible in the resulting package via the `data()` API, and its documentation is accessible via `?cars_over_20`.
 

--- a/inst/extdata/tests/subsetCars.html
+++ b/inst/extdata/tests/subsetCars.html
@@ -313,7 +313,7 @@ $(document).ready(function () {
 
 
 <p>This is a simple Rmd file that demonstrates how DataPackageR processes Rmarkdown files and creates data sets that are then stored in an R data package.</p>
-<p>In the <code>config.yml</code> for this example, this file is listed first, and therefore processed first.</p>
+<p>In the <code>datapackager.yml</code> for this example, this file is listed first, and therefore processed first.</p>
 <p>This particular document simply subsets the <code>cars</code> data set:</p>
 <pre class="r"><code>summary(cars)</code></pre>
 <pre><code>##      speed           dist       
@@ -333,16 +333,16 @@ $(document).ready(function () {
 <h1>Storing data set objects and making making accessible to other processing scripts.</h1>
 <p>When DataPackageR processes this file, it creates this <code>cars_over_20</code> object. After processing the file it does several things:</p>
 <ol style="list-style-type: decimal">
-<li>It compares the objects in the rmarkdown render environment of <code>subsetCars.Rmd</code> against the objects listed in the <code>config.yml</code> file <code>objects</code> property.</li>
+<li>It compares the objects in the rmarkdown render environment of <code>subsetCars.Rmd</code> against the objects listed in the <code>datapackager.yml</code> file <code>objects</code> property.</li>
 <li>It finds <code>cars_over_20</code> is listed there, so it stores it in a new environment.</li>
 <li>That environment is passed to subsequent R and Rmd files. Specifically when the <code>extra.Rmd</code> file is processed, it has access to an environment object that holds all the <code>objects</code> (defined in the yaml config) that have already been created and processed. This environment is passed into subsequent scripts at the <code>render()</code> call.</li>
 </ol>
-<p>All of the above is done automatically. The user only needs to list the objects to be stored and passed to other scripts in the <code>config.yml</code> file.</p>
+<p>All of the above is done automatically. The user only needs to list the objects to be stored and passed to other scripts in the <code>datapackager.yml</code> file.</p>
 <p>The <code>datapackager_object_read()</code> API can be used to retrieve these objects from the environment.</p>
 <div id="storing-objects-in-the-data-package" class="section level3">
 <h3>Storing objects in the data package</h3>
 <p>In addition to passing around an environment to subsequent scripts, the <code>cars_over_20</code> object is stored in the data package <code>/data</code> directory as an <code>rda</code> file.</p>
-<p>Note that this is all done automatically. The user does not need to explicitly save anything, they only need to list the objects to be store in the <code>config.yml</code>.</p>
+<p>Note that this is all done automatically. The user does not need to explicitly save anything, they only need to list the objects to be store in the <code>datapackager.yml</code>.</p>
 <p>This object is then accessible in the resulting package via the <code>data()</code> API, and its documentation is accessible via <code>?cars_over_20</code>.</p>
 </div>
 <div id="data-object-documentation" class="section level3">

--- a/man/DataPackageR-package.Rd
+++ b/man/DataPackageR-package.Rd
@@ -22,7 +22,7 @@ documented and tracked in the final package. Raw data should be read from
 "inst/extdata" but large raw data files can be read from sources external
 to the package source tree.
 
-Configuration is controlled via the config.yml file created at the package root.
+Configuration is controlled via the datapackager.yml file created at the package root.
 Its properties include a list of R and Rmd files that are to be rendered / sourced and
 which read data and do the actual processing.
 It also includes a list of r object names created by those files. These objects
@@ -40,7 +40,7 @@ objects are updated or changed on subsequent builds.
 Once the package is built and installed, the data objects created in the package are accessible via
 the \code{data()} API, and
 Calling \code{datapackage_skeleton()} and passing in R / Rmd file names, and r object names
-constructs a skeleton data package source tree and an associated \code{config.yml} file.
+constructs a skeleton data package source tree and an associated \code{datapackager.yml} file.
 
 Calling \code{package_build()} sets the build process in motion.
 }

--- a/man/datapackager_object_read.Rd
+++ b/man/datapackager_object_read.Rd
@@ -34,7 +34,7 @@ assign("find_me", 100, ENVS) #This is done automatically by DataPackageR
 find_me <- datapackager_object_read("find_me") # This would appear in an Rmd processed by
                                     # DataPackageR to access the object named "find_me" created
                                     # by a previous script. "find_me" would also need to
-                                    # appear in the objects property of config.yml
+                                    # appear in the objects property of datapackager.yml
 }
 }
 }

--- a/tests/testthat/test-edge-cases.R
+++ b/tests/testthat/test-edge-cases.R
@@ -1,123 +1,114 @@
 context("edge cases")
-test_that("package built in different edge cases", {
-  DataPackageR:::.multilog_setup(file.path(tempdir(),"test.log"))
-  DataPackageR:::.multilog_thresold(INFO, TRACE)
-
+test_that("local edge case block 1", {
   file <- system.file("extdata", "tests", "subsetCars.Rmd",
-    package = "DataPackageR"
+                      package = "DataPackageR"
   )
+  td <- withr::local_tempdir()
   datapackage_skeleton(
     name = "subsetCars",
-    path = tempdir(),
-    code_files = c(file),
+    path = td,
+    code_files = file,
     force = TRUE,
     r_object_names = "cars_over_20"
   )
-  expect_error(package_build(packageName = NULL))
-  old <- getwd()
-  setwd(file.path(tempdir(), "subsetCars")) # nolint
-  on.exit(setwd(old)) # nolint
+  withr::with_dir(td, {
+    # error out when wd is the parent directory
+    expect_error(package_build(packageName = NULL))
+  })
+  td_sc <- file.path(td, "subsetCars")
+  withr::with_dir(td_sc, {
+    # successful build when wd is the package directory
+    expect_equal(
+      basename(package_build(packageName = NULL)),
+      "subsetCars_1.0.tar.gz"
+    )
+  })
+  # some yml tests
   expect_equal(
-    basename(package_build(packageName = NULL)),
-    "subsetCars_1.0.tar.gz"
-  )
-  expect_equal(
-    yml_list_objects(file.path(
-      tempdir(),
-      "subsetCars"
-    )),
+    yml_list_objects(td_sc),
     "cars_over_20"
   )
-
-  config <- yml_find(file.path(tempdir(), "subsetCars"))
+  config <- yml_find(td_sc)
   config[["configuration"]]$render_root <- ""
   expect_equal(DataPackageR:::.get_render_root(config), "")
   config[["configuration"]]$render_root <- NULL
   expect_error(DataPackageR:::.get_render_root(config))
-  yml <- construct_yml_config("foo",
-    render_root = normalizePath(tempdir(),
-      winslash = "/"
-    )
-  )
+})
+
+
+test_that("local edge case block 2", {
+  td <- withr::local_tempdir()
+  # This seems like it needs a new tempdir
+  yml <- construct_yml_config("foo", render_root = td)
   expect_equal(
     basename(DataPackageR:::.get_render_root(yml)),
-    basename(normalizePath(tempdir(), winslash = "/"))
+    basename(td)
   )
-  expect_error(package_build(tempdir()))
+  expect_error(package_build(td))
   expect_error(data_version("foo"))
+  # this just errors because 'path' != 'patch'
   expect_error(
     DataPackageR:::.increment_data_version("foo",
-      new_data_digest = "bar",
-      which = "path"
+                                           new_data_digest = "bar",
+                                           which = "path"
     )
   )
-  suppressWarnings(expect_error(DataPackageR:::DataPackageR(tempdir())))
-  unlink(file.path(tempdir(), "foo"),
-    force = TRUE,
-    recursive = TRUE
-  )
+  # errors out on non-package path
+  suppressWarnings(expect_error(DataPackageR:::DataPackageR(td)))
+})
+
+test_that("local edge case block 3", {
+  td <- withr::local_tempdir()
   test_env <- new.env()
   assign('test_obj', pi, envir = test_env)
-  utils::package.skeleton("foo", path = tempdir(), environment = test_env)
+  utils::package.skeleton("foo", path = td, environment = test_env)
+  td_foo <- file.path(td, 'foo')
   suppressWarnings(expect_error(
-    DataPackageR:::DataPackageR(
-      file.path(tempdir(), "foo")
-    )
+    DataPackageR:::DataPackageR(td_foo)
   ))
-  dir.create(file.path(tempdir(), "foo", "data-raw"))
+  dir.create(file.path(td_foo, "data-raw"))
   suppressWarnings(expect_error(
-    DataPackageR:::DataPackageR(
-      file.path(tempdir(), "foo")
-    )
+    DataPackageR:::DataPackageR(td_foo)
   ))
-  unlink(file.path(tempdir(), "foo", "R"),
-    recursive = TRUE,
-    force = TRUE
+  unlink(file.path(td_foo, "R"),
+         recursive = TRUE,
+         force = TRUE
   )
-  unlink(file.path(tempdir(), "foo", "inst"),
-    recursive = TRUE,
-    force = TRUE
+  unlink(file.path(td_foo, "inst"),
+         recursive = TRUE,
+         force = TRUE
   )
   suppressWarnings(expect_error(
-    DataPackageR:::DataPackageR(
-      file.path(tempdir(), "foo")
-    )
+    DataPackageR:::DataPackageR(td_foo)
   ))
-  unlink(file.path(tempdir(), "foo"),
-    force = TRUE,
-    recursive = TRUE
-  )
+})
 
 
-  utils::package.skeleton("foo", path = tempdir(), environment = test_env, force = TRUE)
-  expect_error(yml_find(file.path(tempdir(), "foo")))
-  dir.create(file.path(tempdir(), "foo", "data-raw"))
-  unlink(file.path(tempdir(), "foo", "DESCRIPTION"))
+test_that("local edge case block 4", {
+  test_env <- new.env()
+  assign('test_obj', pi, envir = test_env)
+  td <- withr::local_tempdir()
+  utils::package.skeleton("foo", path = td, environment = test_env, force = TRUE)
+  td_foo <- file.path(td, 'foo')
+  expect_error(yml_find(td_foo))
+  dir.create(file.path(td_foo, "data-raw"))
+  unlink(file.path(td_foo, "DESCRIPTION"))
   yml <- DataPackageR:::construct_yml_config("foo.Rmd")
-  yml_write(yml, path = file.path(tempdir(), "foo"))
+  yml_write(yml, path = td_foo)
   suppressWarnings(expect_error(
-    DataPackageR:::DataPackageR(
-      file.path(tempdir(), "foo")
-    )
+    DataPackageR:::DataPackageR(td_foo)
   ))
   yml$configuration$files <- " "
-  yml_write(yml, path = file.path(tempdir(), "foo"))
-  expect_error(DataPackageR:::DataPackageR(file.path(tempdir(), "foo")))
+  yml_write(yml, path = td_foo)
+  expect_error(DataPackageR:::DataPackageR(td_foo))
+  unlink(td_foo, force = TRUE, recursive = TRUE)
+  suppressWarnings({
+    expect_error(construct_yml_config("foo", render_root = "bar"))
+  })
+})
 
 
-  unlink(file.path(tempdir(), "foo"),
-    force = TRUE,
-    recursive = TRUE
-  )
-  suppressWarnings(expect_error(construct_yml_config("foo",
-    render_root = "bar"
-  )))
-  unlink(file.path(tempdir(), "subsetCars"),
-    recursive = TRUE,
-    force = TRUE
-  )
-  setwd(old)
-
+test_that("local edge case block 5", {
   yml <- DataPackageR:::construct_yml_config("foo.Rmd")
   expect_true(yml_enable_compile(
     yml,
@@ -127,7 +118,7 @@ test_that("package built in different edge cases", {
     yml,
     "foo.Rmd"
   )[["configuration"]][["files"]][["foo.Rmd"]][["enabled"]]) # nolint
-  expect_error(yml_write("/"))
+  expect_error(yml_write("x"))
   expect_equal(
     DataPackageR:::.combine_digests(
       list(
@@ -145,6 +136,10 @@ test_that("package built in different edge cases", {
       foo = "bar"
     )
   )
+})
+
+
+test_that("local edge case block 6", {
   e <- new.env()
   d <- list(DataVersion = "0.1.0")
   assign("a", 10, e)
@@ -155,6 +150,9 @@ test_that("package built in different edge cases", {
       a = "2522027d230e3dfe02d8b6eba1fd73e1"
     )
   )
+})
+
+test_that("local edge case block 7", {
   e <- new.env()
   d <- list()
   assign("a", 10, e)
@@ -164,15 +162,18 @@ test_that("package built in different edge cases", {
     list(DataVersion = "1.1.1"),
     list(DataVersion = "1.a.1")
   )))
+})
 
-  unlink(file.path(tempdir(), "foo"),
-    force = TRUE,
-    recursive = TRUE
-  )
-  utils::package.skeleton("foo", path = tempdir(), environment = test_env, force = TRUE)
-  DataPackageR:::.multilog_setup(file.path(tempdir(),"test.log"))
+
+test_that("local edge case block 8", {
+  test_env <- new.env()
+  assign('test_obj', pi, envir = test_env)
+  td <- withr::local_tempdir()
+  utils::package.skeleton("foo", path = td,
+                          environment = test_env, force = TRUE)
+  td_foo <- file.path(td, 'foo')
+  DataPackageR:::.multilog_setup(file.path(td,"test.log"))
   DataPackageR:::.multilog_thresold(INFO, TRACE)
-
   # data in digest changes while names do not
   suppressWarnings(expect_false({
     DataPackageR:::.compare_digests(
@@ -186,7 +187,6 @@ test_that("package built in different edge cases", {
       )
     )
   }))
-
   # names in digest changes while data do not
   suppressWarnings(expect_false({
     DataPackageR:::.compare_digests(
@@ -200,7 +200,6 @@ test_that("package built in different edge cases", {
       )
     )
   }))
-
   # names in digest nor data changes
   suppressWarnings(expect_true({
     DataPackageR:::.compare_digests(
@@ -214,7 +213,6 @@ test_that("package built in different edge cases", {
       )
     )
   }))
-
   # names in old digest have one more than new
   suppressWarnings(expect_false({
     DataPackageR:::.compare_digests(
@@ -229,7 +227,6 @@ test_that("package built in different edge cases", {
       )
     )
   }))
-
   # names in new digest have one more than old
   suppressWarnings(expect_false({
     DataPackageR:::.compare_digests(
@@ -244,13 +241,12 @@ test_that("package built in different edge cases", {
       )
     )
   }))
-
-  unlink(file.path(tempdir(), "foo"),
-    force = TRUE,
-    recursive = TRUE
+  unlink(td_foo,
+         force = TRUE,
+         recursive = TRUE
   )
-  suppressWarnings(expect_error(yml_list_objects("foo")))
-  expect_false(DataPackageR:::.validate_render_root("/foobar"))
+  suppressWarnings(expect_error(yml_list_objects(td_foo)))
+  expect_false(DataPackageR:::.validate_render_root(file.path(td, 'foobar')))
   suppressWarnings(expect_error(
     DataPackageR:::yml_add_files("subsetCars", "foo.rmd")
   ))
@@ -279,102 +275,106 @@ test_that("package built in different edge cases", {
     "foo.Rmd"
   )[["configuration"]][["files"]])), 0)
   expect_error(DataPackageR::construct_yml_config("foo.Rmd",
-    render_root = "foobar"
+                                                  render_root = "foobar"
   ))
   expect_null(DataPackageR:::datapackage_skeleton(
     name = "foo",
-    path = tempdir()
+    path = td
   ))
-  suppressWarnings(unlink(normalizePath(file.path(
-    tempdir(),
-    "foo"
-  ), winslash = "/"),
-  recursive = TRUE,
-  force = TRUE
-  ))
-  expect_error(DataPackageR:::read_pkg_description("foo"))
-  unlink(file.path(tempdir(), "foo"),
-    force = TRUE,
-    recursive = TRUE
-  )
-  utils::package.skeleton("foo", path = tempdir(), environment = test_env, force = TRUE)
-  dir.create(file.path(tempdir(), "foo", "data-raw"))
   suppressWarnings(
-    expect_error(
-      DataPackageR:::DataPackageR(file.path(
-        tempdir(),
-        "foo"
-      ))
+    unlink(td_foo,
+           recursive = TRUE,
+           force = TRUE
     )
   )
+  expect_error(DataPackageR:::read_pkg_description("foo"))
+})
+
+
+test_that("local edge case block 9", {
+  test_env <- new.env()
+  assign('test_obj', pi, envir = test_env)
+  td <- withr::local_tempdir()
+  utils::package.skeleton("foo", path = td, environment = test_env, force = TRUE)
+  td_foo <- file.path(td, 'foo')
+  dir.create(file.path(td_foo, "data-raw"))
+  suppressWarnings({
+    expect_error(DataPackageR:::DataPackageR(td_foo))
+  })
   yml <- DataPackageR:::construct_yml_config("foo")
-  yml_write(yml, path = file.path(tempdir(), "foo"))
-  expect_error(DataPackageR:::DataPackageR(file.path(tempdir(), "foo")))
+  yml_write(yml, path = td_foo)
+  expect_error(DataPackageR:::DataPackageR(td_foo))
   yml <- DataPackageR:::construct_yml_config("", "bar")
-  yml_write(yml, path = file.path(tempdir(), "foo"))
-  expect_error(DataPackageR:::DataPackageR(file.path(tempdir(), "foo")))
+  yml_write(yml, path = td_foo)
+  expect_error(DataPackageR:::DataPackageR(td_foo))
   unlink(
-    file.path(tempdir(), "foo", "DESCRIPTION"),
+    file.path(td_foo, "DESCRIPTION"),
     force = TRUE,
     recursive = TRUE
   )
-  unlink(file.path(tempdir(), "foo", "config.yml"),
-    force = TRUE,
-    recursive = TRUE
+  unlink(file.path(td_foo, "datapackager.yml"),
+         force = TRUE,
+         recursive = TRUE
   )
   try(usethis::proj_set(NULL),silent = TRUE) #wrap in try for usethis 1.4 vs 1.5
-  expect_error(DataPackageR:::DataPackageR(file.path(tempdir(), "foo")))
+  expect_error(DataPackageR:::DataPackageR(td_foo))
+})
+
+
+test_that("local edge case block 10", {
+  td <- withr::local_tempdir()
   datapackage_skeleton(
     name = "subsetCars",
-    path = tempdir(),
+    path = td,
     code_files = system.file("extdata", "tests", "subsetCars.Rmd",
-      package = "DataPackageR"
+                             package = "DataPackageR"
     ),
     force = TRUE,
     r_object_names = "cars_over_20"
   )
+  td_cars <- file.path(td, 'subsetCars')
   unlink(
-    file.path(tempdir(), "subsetCars", "DESCRIPTION"),
+    file.path(td_cars, "DESCRIPTION"),
     force = TRUE,
     recursive = TRUE
   )
-  suppressWarnings(expect_error(DataPackageR:::DataPackageR(file.path(
-    tempdir(), "subsetCars"
-  ))))
-  unlink(file.path(tempdir(), "subsetCars"),
-    force = TRUE,
-    recursive = TRUE
-  )
+  suppressWarnings(expect_error(DataPackageR:::DataPackageR(td_cars)))
+})
+
+
+test_that("local edge case block 11", {
+  td <- withr::local_tempdir()
   datapackage_skeleton(
     name = "subsetCars",
-    path = tempdir(),
+    path = td,
     code_files = system.file("extdata", "tests", "subsetCars.Rmd",
-      package = "DataPackageR"
+                             package = "DataPackageR"
     ),
     force = TRUE,
     r_object_names = "cars_over_20"
   )
-  yml <- yml_find(file.path(tempdir(), "subsetCars"))
+  td_cars <- file.path(td, 'subsetCars')
+  yml <- yml_find(td_cars)
   ymlbak <- yml
   yml$configuration <- NULL
   yml_write(yml)
-  expect_error(DataPackageR:::DataPackageR(file.path(tempdir(), "subsetCars")))
+  expect_error(DataPackageR:::DataPackageR(td_cars))
   yml <- ymlbak
   yml$configuration$files <- NULL
   yml$configuration$objects <- NULL
   yml_write(yml)
-  expect_error(DataPackageR:::DataPackageR(file.path(tempdir(), "subsetCars")))
+  expect_error(DataPackageR:::DataPackageR(td_cars))
   yml <- ymlbak
   yml_write(yml_disable_compile(yml, "subsetCars.Rmd"))
-  expect_error(DataPackageR:::DataPackageR(file.path(tempdir(), "subsetCars")))
+  expect_error(DataPackageR:::DataPackageR(td_cars))
   yml <- ymlbak
   yml$configuration$render_root <- "foobar"
   yml_write(yml)
-  expect_error(DataPackageR:::DataPackageR(file.path(tempdir(), "subsetCars")))
+  expect_error(DataPackageR:::DataPackageR(td_cars))
   yml <- ymlbak
   yml$configuration$objects <- list()
   yml_write(yml)
-  expect_error(DataPackageR:::DataPackageR(file.path(tempdir(), "subsetCars")))
+  expect_error(DataPackageR:::DataPackageR(td_cars))
   yml <- ymlbak
   yml$configuration$files <-
     list(foo.rmd = list(
@@ -382,11 +382,5 @@ test_that("package built in different edge cases", {
         "foo.rmd", enabled = TRUE
     ))
   yml_write(yml)
-  expect_error(DataPackageR:::DataPackageR(file.path(tempdir(), "subsetCars")))
-  unlink(
-    file.path(tempdir(), "subsetCars", "data"),
-    force = TRUE,
-    recursive = TRUE
-  )
+  expect_error(DataPackageR:::DataPackageR(td_cars))
 })
-


### PR DESCRIPTION
This test file created and sometimes deleted numerous test data packages in temporary directories, and had 300+ lines of test code all scoped inside the same testthat block.  As such, it was confusing to follow and maybe prone to some hard-to-notice test inter-dependencies.

This PR splits up those tests into 11 different blocks, each with locally scoped variables and locally scoped auto-deleting temporary directories.  This was needed prep for some upcoming refactoring I wanted to do, and will be useful for eventual re-organizing of the test files. There's still room to improve these tests, which didn't have many code comments.

This PR also renames `config.yml` to `datapackager.yml` in the documentation (inspired by finding an old instance of that filename lingering in the test code itself).