### PR TITLE
Miscellaneous minor improvements

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,77 +1,65 @@
-Package: DataPackageR
 Type: Package
+Package: DataPackageR
 Title: Construct Reproducible Analytic Data Sets as R Packages
-Authors@R:
-    c(person(given = "Greg", family = "Finak",
-             role = c("aut","cph"),
-             email = "greg.finak@gmail.com",
-             comment = "Original author and creator of DataPackageR"),
-      person(given = "Paul", family = "Obrecht",
-             role = c("ctb")),
-      person(given = "Ellis", family = "Hughes",
-              role = c("ctb"),
-              email = "ellishughes@live.com",
-              comment = c(ORCID = "0000-0003-0637-4436")),
-      person(given = "Jimmy", family = "Fulp",
-              role = c("ctb"),
-              email = "williamjfulp@gmail.com"),
-      person(given = "Marie", family = "Vendettuoli",
-              role = c("ctb"),
-              comment = c(ORCID = "0000-0001-9321-1410")),
-      person(given = "Dave", family = "Slager",
-              role = c("ctb", "cre"),
-              email = "dslager@scharp.org",
-              comment = c(ORCID = "0000-0003-2525-2039")),
-      person(given = "Jason", family = "Taylor",
-              role = c("ctb"),
-              email = "jmtaylor@fredhutch.org"),
-      person(given = "Kara", family = "Woo",
-              role = "rev",
-              comment = "Kara reviewed the package for rOpenSci, see <https://github.com/ropensci/onboarding/issues/230>"),
-      person(given = "William", family = "Landau",
-              role = "rev",
-      comment = "William reviewed the package for rOpenSci, see <https://github.com/ropensci/onboarding/issues/230>"))
 Version: 0.15.9.9000
+Authors@R:c(
+    person("Greg", "Finak", , "greg.finak@gmail.com", role = c("aut", "cph"),
+           comment = "Original author and creator of DataPackageR"),
+    person("Paul", "Obrecht", role = "ctb"),
+    person("Ellis", "Hughes", , "ellishughes@live.com", role = "ctb",
+           comment = c(ORCID = "0000-0003-0637-4436")),
+    person("Jimmy", "Fulp", , "williamjfulp@gmail.com", role = "ctb"),
+    person("Marie", "Vendettuoli", role = "ctb",
+           comment = c(ORCID = "0000-0001-9321-1410")),
+    person("Dave", "Slager", , "dslager@fredhutch.org", role = c("ctb", "cre"),
+           comment = c(ORCID = "0000-0003-2525-2039")),
+    person("Jason", "Taylor", , "jmtaylor@fredhutch.org", role = "ctb"),
+    person("Kara", "Woo", role = "rev",
+           comment = "Kara reviewed the package for rOpenSci, see <https://github.com/ropensci/onboarding/issues/230>"),
+    person("William", "Landau", role = "rev",
+           comment = "William reviewed the package for rOpenSci, see <https://github.com/ropensci/onboarding/issues/230>")
+  )
 Description: A framework to help construct R data packages in a
-  reproducible manner. Potentially time consuming processing of
-  raw data sets into analysis ready data sets is done in a reproducible
-  manner and decoupled from the usual 'R CMD build' process so that
-  data sets can be processed into R objects in the data package and
-  the data package can then be shared, built, and installed by others
-  without the need to repeat computationally costly data processing.
-  The package maintains data provenance by turning the data processing
-  scripts into package vignettes, as well as enforcing documentation
-  and version checking of included data objects. Data packages can be
-  version controlled on 'GitHub', and used to share data for manuscripts,
-  collaboration and reproducible research.
+    reproducible manner. Potentially time consuming processing of raw data
+    sets into analysis ready data sets is done in a reproducible manner
+    and decoupled from the usual 'R CMD build' process so that data sets
+    can be processed into R objects in the data package and the data
+    package can then be shared, built, and installed by others without the
+    need to repeat computationally costly data processing.  The package
+    maintains data provenance by turning the data processing scripts into
+    package vignettes, as well as enforcing documentation and version
+    checking of included data objects. Data packages can be version
+    controlled on 'GitHub', and used to share data for manuscripts,
+    collaboration and reproducible research.
 License: MIT + file LICENSE
-Depends: R (>= 3.5.0)
-Imports:
-    digest,
-    knitr,
-    rmarkdown,
-    desc,
-    yaml,
-    purrr,
-    roxygen2,
-    futile.logger,
-    rprojroot,
-    usethis,
-    crayon,
-    pkgbuild,
-    pkgload
-VignetteBuilder: knitr
-RoxygenNote: 7.3.1
-Encoding: UTF-8
-Suggests:
-    spelling,
-    testthat,
-    covr,
-    data.tree,
-    withr
-URL:
-    https://github.com/ropensci/DataPackageR,
+URL:https://github.com/ropensci/DataPackageR,
     https://docs.ropensci.org/DataPackageR/
 BugReports: https://github.com/ropensci/DataPackageR/issues
-SystemRequirements: pandoc (>= 1.12.3) - https://pandoc.org
+Depends:
+    R (>= 3.5.0)
+Imports:
+    crayon,
+    desc,
+    digest,
+    futile.logger,
+    knitr,
+    pkgbuild,
+    pkgload,
+    purrr,
+    rmarkdown,
+    roxygen2,
+    rprojroot,
+    usethis,
+    yaml
+Suggests:
+    covr,
+    data.tree,
+    spelling,
+    testthat,
+    withr
+VignetteBuilder:
+    knitr
+Encoding: UTF-8
 Language: en-US
+RoxygenNote: 7.3.1
+SystemRequirements: pandoc - https://pandoc.org

--- a/R/logger.R
+++ b/R/logger.R
@@ -39,6 +39,10 @@ select_console_appender <- function(){
 
 .multilog_setup <- function(LOGFILE = NULL) {
   if (!is.null(LOGFILE)) {
+    if (file.exists(LOGFILE)){
+      # initial newline to separate from previous run log entries
+      cat("\n", file = LOGFILE, append = TRUE)
+    }
     flog.logger(
       name = "logfile",
       appender = appender.file(LOGFILE),

--- a/R/processData.R
+++ b/R/processData.R
@@ -520,32 +520,18 @@ do_doc <- function(pkg_dir, dataenv) {
       new = missing_doc
     )
     file.info("Writing merged docs.")
-    local({
-      on.exit(close(docfile))
-      docfile <- file(
-        file.path(pkg_dir, 'data-raw', "documentation.R"),
-        open = "w"
-      )
-      for (i in seq_along(doc_parsed)) {
-        writeLines(text = doc_parsed[[i]], con = docfile)
-      }
-    })
+    writeLines(Reduce(c, doc_parsed),
+               file.path(pkg_dir, 'data-raw', "documentation.R")
+    )
   }
   # Partial build if enabled=FALSE for
   # any file We've disabled an object but don't
   # want to overwrite its documentation
   # or remove it The new approach just builds
   # all the docs independent of what's enabled.
-  save_docs <- do.call(c, doc_parsed)
-  docfile <- file(file.path(pkg_dir, "R",
-                            pattern = paste0(pkg_name, ".R")
-  ),
-  open = "w"
+  writeLines(Reduce(c, doc_parsed),
+             file.path(pkg_dir, "R", paste0(pkg_name, ".R"))
   )
-  for (i in seq_along(save_docs)) {
-    writeLines(text = save_docs[[i]], con = docfile)
-  }
-  close(docfile)
   .multilog_trace(
     paste0(
       "Copied documentation to ",

--- a/R/processData.R
+++ b/R/processData.R
@@ -95,8 +95,7 @@ DataPackageR <- function(arg = NULL, deps = TRUE) {
     if (deps) assign(x = "ENVS", value = ENVS, dataenv)
     .multilog_trace(paste0(
       "Processing ", i, " of ",
-      length(r_files), ": ", r_files[i],
-      "\n"
+      length(r_files), ": ", r_files[i]
     ))
     # config file goes in the root render the r and rmd files
     ## First we spin then render if it's an R file

--- a/R/processData.R
+++ b/R/processData.R
@@ -168,7 +168,7 @@ DataPackageR <- function(arg = NULL, deps = TRUE) {
         "Built ",
         ifelse(
           sum(object_tally) == length(object_tally),
-          " all datasets!",
+          "all datasets!",
           paste0(sum(object_tally), " of ",
                  length(object_tally), " data sets.")
         )

--- a/man/DataPackageR-package.Rd
+++ b/man/DataPackageR-package.Rd
@@ -98,7 +98,7 @@ Useful links:
 
 }
 \author{
-\strong{Maintainer}: Dave Slager \email{dslager@scharp.org} (\href{https://orcid.org/0000-0003-2525-2039}{ORCID}) [contributor]
+\strong{Maintainer}: Dave Slager \email{dslager@fredhutch.org} (\href{https://orcid.org/0000-0003-2525-2039}{ORCID}) [contributor]
 
 Authors:
 \itemize{


### PR DESCRIPTION
Miscellaneous minor improvements:

- Alphabetize packages in DataPackageR's DESCRIPTION file using `desc::`
- `cat` a newline to the Logfile on first write if Logfile already exists.
   - This makes a nice visual separation between consecutive package rebuilds
- Remove a newline that was put into the Logfile mid-build
   - Now line breaks will indicate a different package_build attempt
- Remove an extra space in console informational output
- Simplify some calls to `writeLines()` including one that was an unnecessary tight loop
- No changes to functionality, minor UI improvements