### PR TITLE
rm old news item that ended up in 0.15.9

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -64,7 +64,6 @@
 * Close a file connection, suppressing warnings about orphaned connections
 * Fix broken test that led to archiving on CRAN
 * Fix package documentation method for data packages and DataPackageR itself (r-lib/roxygen2#1491)
-* Fix tests for compatibility with usethis >1.5.2
 
 ## Minor improvements
 


### PR DESCRIPTION
References older usethis version than an even older news item, so it seems this never belonged here.