### PR TITLE
Normalize path for render_root in yml to fix relative paths

### DIFF
--- a/tests/testthat/test-build-locations.R
+++ b/tests/testthat/test-build-locations.R
@@ -42,3 +42,32 @@ test_that("Error on data pkg dirname different from data pkg name", {
                    "name of the data package directory")
   expect_error(package_build(file.path(td, not_sn)), err_msg)
 })
+
+test_that("properly handle relative render_root path from yaml config", {
+  # A lightly modified version of Jason's reprex
+  withr::with_tempdir({
+    datapackage_skeleton("new")
+
+    utils::write.csv(data.frame(x=1:10),
+              file.path('new', 'inst', 'extdata', 'ext.csv'),
+              row.names=F)
+
+    x <- "x <- read.csv(file.path('inst', 'extdata', 'ext.csv'))"
+    writeLines(x, file.path('new', 'data-raw', 'x.R'))
+
+    config <- yml_add_files("new", "x.R")
+    config <- yml_add_objects(config, "x")
+    config <- yml_write(config, "new")
+
+    yml <- yaml::read_yaml(file.path("new", "datapackager.yml"))
+    yml$configuration$render_root$tmp <- NULL
+    yml$configuration$render_root <- "./"
+    yaml::write_yaml(yml, file.path("new", "datapackager.yml"))
+
+    expect_error(package_build())
+
+    withr::with_dir('new', {
+      expect_no_error(package_build())
+    })
+  })
+})

--- a/tests/testthat/test-edge-cases.R
+++ b/tests/testthat/test-edge-cases.R
@@ -298,7 +298,7 @@ test_that("local edge case block 8", {
          recursive = TRUE
   )
   suppressWarnings(expect_error(yml_list_objects(td_foo)))
-  expect_false(DataPackageR:::.validate_render_root(file.path(td, 'foobar')))
+  expect_error(DataPackageR:::.validate_render_root(file.path(td, 'foobar')))
   suppressWarnings(expect_error(
     DataPackageR:::yml_add_files("subsetCars", "foo.rmd")
   ))


### PR DESCRIPTION
Fixed an issue found by @jmtaylor-fhcrc during interactive testing where `rmarkdown::render()` fails when render_root is given as `./` in yml config.

Basically, render_root path needs to be normalized before passing to `rmarkdown::render()`.

This originally happened but got broken by commit 519fadb6c089a1144da9200e385249b225b87ae2.

Fixed the regression and added new tests for the behavior expected by Jason's reprex.