### PR TITLE
Don't overwrite DataPackageR_verbose option set outside package

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,7 @@
   - `dataVersion()`, renamed years ago to `data_version()`
   - `datapackage.skeleton()`, renamed years ago to `datapackage_skeleton()`
   - `keepDataObjects()`
+* Keep existing DataPackageR_verbose option if set outside of package
 
 ## Internal improvements
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,11 +1,11 @@
 .onLoad <- function(libname, pkgname) {
   # keeping this first option hardcoded on load for now
   options("DataPackageR_packagebuilding" = FALSE)
-  options("DataPackageR_verbose" = TRUE)
-  # respect previous user setting for 'DataPackageR_interact' if set
+  # respect previous user setting for options if set
   op <- options()
   op.DataPackageR <- list(
-    DataPackageR_interact = interactive()
+    DataPackageR_interact = interactive(),
+    DataPackageR_verbose = TRUE
   )
   toset <- !(names(op.DataPackageR) %in% names(op))
   if (any(toset)) options(op.DataPackageR[toset])


### PR DESCRIPTION
Fixes https://github.com/ropensci/DataPackageR/issues/154.

Interactively tested that this removes the verbosity as expected in the VISCtemplates unit tests while keeping verbosity interactively.