### PR TITLE
enforce 3-component DataVersion

### DIFF
--- a/R/processData.R
+++ b/R/processData.R
@@ -346,11 +346,8 @@ validate_DataVersion <- function(DataVersion){
             length(DataVersion) == 1,
             ! is.na(DataVersion)
   )
-  # base::package_version() does additional version-related validation here
-  dv <- package_version(DataVersion)
-  # error out if it is not a valid 3-number version (major, minor, patch)
-  stopifnot(! is.na(dv[1, 1:3]))
-  as.character(dv)
+  # base::R_system_version enforces valid 3-number version (major, minor, patch)
+  as.character(R_system_version(DataVersion))
 }
 
 #' do_digests() function extracted out from DataPackageR

--- a/tests/testthat/test-edge-cases.R
+++ b/tests/testthat/test-edge-cases.R
@@ -160,6 +160,7 @@ test_that("validate_DataVersion works as expected", {
   expect_equal(validate_DataVersion('0.1.0'), '0.1.0')
   # needs to be a 3-part version
   expect_error(validate_DataVersion('1.0'))
+  expect_error(validate_DataVersion('1.0.0.1'))
   # works as expected on valid input
   expect_equal(
     validate_DataVersion(package_version('0.1.0')),


### PR DESCRIPTION
3-component `DataVersion` strings have always been assumed, but `validate_DataVersion()` still allowed for 4+ components.

Three components are now enforced via the built-in base R function `R_system_version()`, which conveniently does this exact thing. Added an additional test.