### PR TITLE
Overwrite invalid ORCID placeholder created by usethis that errors on build in R >= 4.5.x

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # DataPackageR (development version)
 
+## Minor user-facing improvements
+* Suppress warning from project*_path() functions when file does not exist (#160)
+
+## Maintenance
+* Remove dependency on crayon package, switch to cli package (#159)
+* Remove invalid ORCID placeholder created by usethis that caused failing CRAN checks (#162)
+
 # DataPackageR 0.16.0
 
 ## Bug fixes

--- a/R/skeleton.R
+++ b/R/skeleton.R
@@ -80,9 +80,6 @@ datapackage_skeleton <-
     }
     description <-
       desc::desc(file = file.path(package_path, "DESCRIPTION"))
-    description$set_authors(
-      utils::person("First", "Last", , "first.last@example.com",
-                    role = c("aut", "cre")))
     description$set("DataVersion" = "0.1.0")
     description$set("Version" = "1.0")
     description$set("Package" = name)

--- a/R/skeleton.R
+++ b/R/skeleton.R
@@ -69,7 +69,15 @@ datapackage_skeleton <-
     }
     package_path <- usethis::create_package(
       path = file.path(path, name),
-      rstudio = FALSE, open = FALSE
+      # fields override for usethis 3.0.0 ORCID placeholder, errors out in R 4.5
+      # https://github.com/r-lib/usethis/issues/2059
+      # can remove fields argument here once fixed upstream
+      fields = list(
+        `Authors@R` = paste0(
+          "person(\"First\", \"Last\", email = \"first.last",
+          "@example.com\", role = c(\"aut\", \"cre\"))"
+        )
+      ), rstudio = FALSE, open = FALSE
     )
     # compatibility between usethis 1.4 and 1.5.
     if(is.character(package_path)){

--- a/R/skeleton.R
+++ b/R/skeleton.R
@@ -80,6 +80,9 @@ datapackage_skeleton <-
     }
     description <-
       desc::desc(file = file.path(package_path, "DESCRIPTION"))
+    description$set_authors(
+      utils::person("First", "Last", , "first.last@example.com",
+                    role = c("aut", "cre")))
     description$set("DataVersion" = "0.1.0")
     description$set("Version" = "1.0")
     description$set("Package" = name)

--- a/R/skeleton.R
+++ b/R/skeleton.R
@@ -71,7 +71,6 @@ datapackage_skeleton <-
       path = file.path(path, name),
       # fields override for usethis 3.0.0 ORCID placeholder, errors out in R 4.5
       # https://github.com/r-lib/usethis/issues/2059
-      # can remove fields argument here once fixed upstream
       fields = list(
         `Authors@R` = paste0(
           "person(\"First\", \"Last\", email = \"first.last",

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -5,11 +5,6 @@
 ❯ checking CRAN incoming feasibility ... [139s] NOTE
   Maintainer: 'Dave Slager <dslager@fredhutch.org>'
 
-  New maintainer:
-    Dave Slager <dslager@fredhutch.org>
-  Old maintainer(s):
-    Dave Slager <dslager@scharp.org>
-
 ## Reverse dependency checks
 
 This package has no reverse dependencies.

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -25,6 +25,7 @@ YAML
 al
 bepress
 bioRxiv
+cli
 config
 csv
 datapack


### PR DESCRIPTION
See: https://github.com/r-lib/usethis/issues/2059

Adding a work-around in DataPackageR, since it sounds like usethis is not going to change this.